### PR TITLE
Add fixed player list GUI layout with navigation

### DIFF
--- a/src/main/kotlin/pl/syntaxdevteam/punisher/commands/CommandManager.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/commands/CommandManager.kt
@@ -106,6 +106,11 @@ class CommandManager(private val plugin: PunisherX) {
                 plugin.messageHandler.getSimpleMessage("change-reason", "usage"),
                 ChangeReasonCommand(plugin)
             )
+            commands.register(
+                "playerlistgui",
+                "Opens player list GUI",
+                PlayerListCommand(plugin)
+            )
             commands.register("clearall", plugin.messageHandler.getSimpleMessage("clear", "usage"), ClearAllCommand(plugin))
             val aliases = plugin.config.getConfigurationSection("aliases")
             aliases?.getKeys(false)?.forEach { key ->

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/commands/PlayerListCommand.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/commands/PlayerListCommand.kt
@@ -1,0 +1,20 @@
+package pl.syntaxdevteam.punisher.commands
+
+import io.papermc.paper.command.brigadier.BasicCommand
+import io.papermc.paper.command.brigadier.CommandSourceStack
+import org.bukkit.entity.Player
+import org.jetbrains.annotations.NotNull
+import pl.syntaxdevteam.punisher.PunisherX
+import pl.syntaxdevteam.punisher.gui.PlayerListGUI
+
+class PlayerListCommand(private val plugin: PunisherX) : BasicCommand {
+    override fun execute(@NotNull stack: CommandSourceStack, @NotNull args: Array<String>) {
+        if (stack.sender !is Player) {
+            stack.sender.sendMessage(plugin.messageHandler.getLogMessage("error", "console"))
+            return
+        }
+
+        val player = stack.sender as Player
+        PlayerListGUI(plugin).open(player)
+    }
+}

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/gui/PlayerListGUI.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/gui/PlayerListGUI.kt
@@ -11,6 +11,7 @@ import org.bukkit.inventory.InventoryHolder
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.SkullMeta
 import pl.syntaxdevteam.punisher.PunisherX
+import pl.syntaxdevteam.punisher.gui.PunisherMain
 
 /**
  * GUI displaying currently online players.
@@ -34,17 +35,15 @@ class PlayerListGUI(private val plugin: PunisherX) : GUI {
      */
     private fun open(player: Player, page: Int) {
         val online = plugin.server.onlinePlayers.toList()
-        val playersPerPage = 45 // 5 rows of heads
+        val playersPerPage = 27 // 3 rows of heads
         val totalPages = if (online.isEmpty()) 1 else (online.size - 1) / playersPerPage + 1
         val currentPage = page.coerceIn(0, totalPages - 1)
 
         val startIndex = currentPage * playersPerPage
         val playersPage = online.drop(startIndex).take(playersPerPage)
 
-        val rows = ((playersPage.size - 1) / 9 + 2).coerceAtLeast(2)
-        val size = rows * 9
         val holder = Holder(currentPage)
-        val inventory = Bukkit.createInventory(holder, size, getTitle())
+        val inventory = Bukkit.createInventory(holder, 45, getTitle())
         holder.inv = inventory
 
         playersPage.forEachIndexed { index, target ->
@@ -65,14 +64,18 @@ class PlayerListGUI(private val plugin: PunisherX) : GUI {
             head.itemMeta = meta
             inventory.setItem(index, head)
         }
+        // Separator row
+        for (slot in 27 until 36) {
+            inventory.setItem(slot, createFillerItem())
+        }
 
-        if (totalPages > 1) {
-            if (currentPage > 0) {
-                inventory.setItem(size - 9, createNavItem(Material.PAPER, "<yellow>Poprzednia strona</yellow>"))
-            }
-            if (currentPage < totalPages - 1) {
-                inventory.setItem(size - 1, createNavItem(Material.BOOK, "<yellow>Następna strona</yellow>"))
-            }
+        // Navigation row
+        if (currentPage > 0) {
+            inventory.setItem(36, createNavItem(Material.PAPER, "<yellow>Poprzednia strona</yellow>"))
+        }
+        inventory.setItem(40, createNavItem(Material.BARRIER, "<yellow>Powrót</yellow>"))
+        if (currentPage < totalPages - 1) {
+            inventory.setItem(44, createNavItem(Material.BOOK, "<yellow>Następna strona</yellow>"))
         }
 
         player.openInventory(inventory)
@@ -84,14 +87,14 @@ class PlayerListGUI(private val plugin: PunisherX) : GUI {
         val player = event.whoClicked as? Player ?: return
 
         val online = plugin.server.onlinePlayers.toList()
-        val playersPerPage = 45
+        val playersPerPage = 27
         val totalPages = if (online.isEmpty()) 1 else (online.size - 1) / playersPerPage + 1
-        val inventorySize = event.view.topInventory.size
         val slot = event.rawSlot
 
         when (slot) {
-            inventorySize - 9 -> if (holder.page > 0) open(player, holder.page - 1)
-            inventorySize - 1 -> if (holder.page < totalPages - 1) open(player, holder.page + 1)
+            36 -> if (holder.page > 0) open(player, holder.page - 1)
+            40 -> PunisherMain(plugin).open(player)
+            44 -> if (holder.page < totalPages - 1) open(player, holder.page + 1)
         }
     }
 
@@ -102,6 +105,14 @@ class PlayerListGUI(private val plugin: PunisherX) : GUI {
         val item = ItemStack(material)
         val meta = item.itemMeta
         meta.displayName(plugin.messageHandler.formatMixedTextToMiniMessage(name, TagResolver.empty()))
+        item.itemMeta = meta
+        return item
+    }
+
+    private fun createFillerItem(): ItemStack {
+        val item = ItemStack(Material.GRAY_STAINED_GLASS_PANE)
+        val meta = item.itemMeta
+        meta.displayName(Component.text(" "))
         item.itemMeta = meta
         return item
     }


### PR DESCRIPTION
## Summary
- Fix PlayerListGUI to use 5x9 layout with navigation buttons and return option
- Add command to open player list GUI for testing

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ec289093c8329b7f56966a784405b