### PR TITLE
Handle GeoIP work asynchronously

### DIFF
--- a/src/main/kotlin/pl/syntaxdevteam/punisher/players/PlayerIPManager.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/players/PlayerIPManager.kt
@@ -4,7 +4,9 @@ import pl.syntaxdevteam.punisher.PunisherX
 import org.bukkit.event.player.PlayerJoinEvent
 import java.io.File
 import java.security.Key
-import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.*
 import javax.crypto.Cipher
 import javax.crypto.spec.SecretKeySpec
@@ -22,7 +24,8 @@ class PlayerIPManager(private val plugin: PunisherX, val geoIPHandler: GeoIPHand
 
     private val cacheFile = File(plugin.dataFolder, "cache")
     private val secretKey: Key = generateKey()
-    private val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    private val dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+        .withZone(ZoneId.systemDefault())
 
     private val useDatabase = plugin.config.getString("playerCache.storage")
         ?.equals("database", ignoreCase = true) == true
@@ -42,11 +45,13 @@ class PlayerIPManager(private val plugin: PunisherX, val geoIPHandler: GeoIPHand
         val playerUUID = player.uniqueId.toString()
         val playerIP = player.address?.address?.hostAddress
 
-        if (playerIP != null) {
+        if (playerIP == null) return
+
+        plugin.schedulerAdapter.runAsync(Runnable {
             val country = geoIPHandler.getCountry(playerIP)
             val city = geoIPHandler.getCity(playerIP)
             val geoLocation = "$city, $country"
-            val lastUpdated = dateFormat.format(Date())
+            val lastUpdated = dateFormatter.format(Instant.now())
 
             if (getPlayerInfo(playerName, playerUUID, playerIP) == null) {
                 savePlayerInfo(playerName, playerUUID, playerIP, geoLocation, lastUpdated)
@@ -54,7 +59,7 @@ class PlayerIPManager(private val plugin: PunisherX, val geoIPHandler: GeoIPHand
             } else {
                 plugin.logger.debug("Player info already exists -> playerName: $playerName, playerUUID: $playerUUID, playerIP: $playerIP, geoLocation: $geoLocation, lastUpdated: $lastUpdated")
             }
-        }
+        })
     }
 
     private fun getPlayerInfo(playerName: String, playerUUID: String, playerIP: String): PlayerInfo? {


### PR DESCRIPTION
## Summary
- initialize GeoIP database asynchronously using the scheduler adapter and reuse a shared DatabaseReader instance
- move player join GeoIP lookups and storage work off the main thread and adopt thread-safe timestamp formatting

## Testing
- ./gradlew test --console=plain


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b7e0866d48329bf4e31ae1fe10e99)