### PR TITLE
Add Paper GUI adapter integration tests and example wiring

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,22 @@ subprojects {
 
     group = rootProject.group
     version = bridgeVersion
+
+    repositories {
+        maven("https://nexus.syntaxdevteam.pl/repository/maven-snapshots/")
+        maven("https://nexus.syntaxdevteam.pl/repository/maven-releases/")
+        gradlePluginPortal()
+        mavenCentral()
+        maven("https://repo.papermc.io/repository/maven-public/")
+        maven("https://oss.sonatype.org/content/groups/public/")
+        maven("https://repo.menthamc.org/repository/maven-public/")
+        maven("https://repo.extendedclip.com/releases/")
+        maven("https://repo.codemc.org/repository/maven-public/")
+        maven("https://jitpack.io")
+        maven("https://repo.essentialsx.net/releases/")
+        maven("https://repo.leavesmc.org/snapshots/")
+        maven("https://repo.faststats.dev/releases")
+    }
 }
 
 val targetJavaVersion = 21
@@ -88,10 +104,11 @@ dependencies {
     compileOnly("dev.faststats.metrics:bukkit:0.22.0")
 
     testImplementation(kotlin("test"))
-    testImplementation("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    testImplementation("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
     testImplementation("org.mockito:mockito-core:5.23.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.3.0")
+    testImplementation("com.github.seeseemelk:MockBukkit-v1.21:3.133.2")
     mockitoAgent("net.bytebuddy:byte-buddy-agent:1.18.8") {
         isTransitive = false
     }

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -1,0 +1,11 @@
+dependencies {
+    compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
+    implementation(project(":"))
+}
+
+tasks.processResources {
+    filteringCharset = "UTF-8"
+    filesMatching(listOf("paper-plugin.yml")) {
+        expand(mapOf("version" to project.version.toString()))
+    }
+}

--- a/example/src/main/kotlin/pl/syntaxdevteam/punisher/example/ExamplePaperAdapterPlugin.kt
+++ b/example/src/main/kotlin/pl/syntaxdevteam/punisher/example/ExamplePaperAdapterPlugin.kt
@@ -1,0 +1,69 @@
+package pl.syntaxdevteam.punisher.example
+
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.format.NamedTextColor
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.player.PlayerJoinEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.plugin.java.JavaPlugin
+import pl.syntaxdevteam.punisher.gui.paper.NavigationComponents
+import pl.syntaxdevteam.punisher.gui.paper.PaperGuiAdapter
+import pl.syntaxdevteam.punisher.gui.paper.PaperScreen
+
+/**
+ * Example module showing how to connect listener + renderer via [PaperGuiAdapter].
+ */
+class ExamplePaperAdapterPlugin : JavaPlugin(), Listener {
+
+    private lateinit var adapter: PaperGuiAdapter
+
+    override fun onEnable() {
+        adapter = PaperGuiAdapter(this)
+            .register(ExampleScreen())
+        adapter.registerListener()
+        server.pluginManager.registerEvents(this, this)
+    }
+
+    @EventHandler
+    fun onPlayerJoin(event: PlayerJoinEvent) {
+        adapter.open(event.player, ExampleScreen.ID)
+    }
+
+    private class ExampleScreen : PaperScreen {
+        companion object {
+            const val ID = "example-main"
+        }
+
+        override val id: String = ID
+
+        override fun title(viewer: Player): Component =
+            Component.text("PunisherX Example", NamedTextColor.GOLD)
+
+        override fun render(viewer: Player, inventory: Inventory) {
+            val center = org.bukkit.inventory.ItemStack(Material.EMERALD)
+            val meta = center.itemMeta
+            meta.displayName(Component.text("Przerysuj", NamedTextColor.GREEN))
+            center.itemMeta = meta
+            inventory.setItem(22, center)
+
+            NavigationComponents.place(
+                inventory = inventory,
+                back = NavigationComponents.back(Component.text("Zamknij", NamedTextColor.RED)),
+                redraw = NavigationComponents.redraw(Component.text("Odśwież", NamedTextColor.YELLOW))
+            )
+        }
+
+        override fun handleClick(event: org.bukkit.event.inventory.InventoryClickEvent, adapter: PaperGuiAdapter) {
+            event.isCancelled = true
+            val player = event.whoClicked as? Player ?: return
+            when (event.rawSlot) {
+                NavigationComponents.BACK_SLOT -> player.closeInventory()
+                NavigationComponents.REDRAW_SLOT,
+                22 -> adapter.redraw(player)
+            }
+        }
+    }
+}

--- a/example/src/main/resources/paper-plugin.yml
+++ b/example/src/main/resources/paper-plugin.yml
@@ -1,0 +1,6 @@
+name: PunisherXExample
+version: ${version}
+main: pl.syntaxdevteam.punisher.example.ExamplePaperAdapterPlugin
+api-version: '1.21'
+authors: [SyntaxDevTeam]
+description: Example plugin module showing PaperGuiAdapter wiring.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "PunisherX"
 include("PunisherX-BungeeCord-Bridge")
 include("PunisherX-Velocity-Bridge")
+include("example")
 
 project(":PunisherX-BungeeCord-Bridge").projectDir = file("bungee-bridge")
 project(":PunisherX-Velocity-Bridge").projectDir = file("velocity-bridge")
@@ -18,3 +19,5 @@ pluginManagement {
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
+
+project(":example").projectDir = file("example")

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/gui/paper/NavigationComponents.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/gui/paper/NavigationComponents.kt
@@ -1,0 +1,45 @@
+package pl.syntaxdevteam.punisher.gui.paper
+
+import net.kyori.adventure.text.Component
+import org.bukkit.Material
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Reusable navigation controls matching the common PunisherX screen layout.
+ */
+object NavigationComponents {
+    const val PREVIOUS_SLOT = 36
+    const val BACK_SLOT = 40
+    const val NEXT_SLOT = 44
+    const val REDRAW_SLOT = 42
+
+    fun previous(label: Component): ItemStack = navItem(Material.PAPER, label)
+
+    fun back(label: Component): ItemStack = navItem(Material.BARRIER, label)
+
+    fun next(label: Component): ItemStack = navItem(Material.BOOK, label)
+
+    fun redraw(label: Component): ItemStack = navItem(Material.SUNFLOWER, label)
+
+    fun place(
+        inventory: Inventory,
+        previous: ItemStack? = null,
+        back: ItemStack,
+        next: ItemStack? = null,
+        redraw: ItemStack? = null
+    ) {
+        if (previous != null) inventory.setItem(PREVIOUS_SLOT, previous)
+        inventory.setItem(BACK_SLOT, back)
+        if (next != null) inventory.setItem(NEXT_SLOT, next)
+        if (redraw != null) inventory.setItem(REDRAW_SLOT, redraw)
+    }
+
+    private fun navItem(material: Material, label: Component): ItemStack {
+        val item = ItemStack(material)
+        val meta = item.itemMeta
+        meta.displayName(label)
+        item.itemMeta = meta
+        return item
+    }
+}

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/gui/paper/PaperGuiAdapter.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/gui/paper/PaperGuiAdapter.kt
@@ -1,0 +1,68 @@
+package pl.syntaxdevteam.punisher.gui.paper
+
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.Inventory
+import org.bukkit.inventory.InventoryHolder
+import org.bukkit.plugin.java.JavaPlugin
+import java.util.UUID
+
+/**
+ * Adapter responsible for opening, redrawing and routing clicks for Paper inventory screens.
+ */
+class PaperGuiAdapter(private val plugin: JavaPlugin) : Listener {
+
+    private val screens = mutableMapOf<String, PaperScreen>()
+
+    fun register(screen: PaperScreen): PaperGuiAdapter {
+        screens[screen.id] = screen
+        return this
+    }
+
+    fun registerListener() {
+        plugin.server.pluginManager.registerEvents(this, plugin)
+    }
+
+    fun open(player: Player, screenId: String) {
+        val screen = screens[screenId] ?: return
+        val inventory = createInventory(player, screen)
+        screen.render(player, inventory)
+        player.openInventory(inventory)
+    }
+
+    fun redraw(player: Player) {
+        val holder = player.openInventory.topInventory.holder as? ScreenHolder ?: return
+        val screen = screens[holder.screenId] ?: return
+        val inventory = player.openInventory.topInventory
+        inventory.clear()
+        screen.render(player, inventory)
+    }
+
+    @EventHandler
+    fun onInventoryClick(event: InventoryClickEvent) {
+        val holder = event.view.topInventory.holder as? ScreenHolder ?: return
+        if (holder.viewerId != event.whoClicked.uniqueId) return
+        val screen = screens[holder.screenId] ?: return
+        screen.handleClick(event, this)
+    }
+
+    private fun createInventory(player: Player, screen: PaperScreen): Inventory {
+        val holder = ScreenHolder(player.uniqueId, screen.id)
+        val inventory = Bukkit.createInventory(holder, screen.size(player), screen.title(player))
+        holder.bind(inventory)
+        return inventory
+    }
+
+    data class ScreenHolder(val viewerId: UUID, val screenId: String) : InventoryHolder {
+        private lateinit var backingInventory: Inventory
+
+        fun bind(inventory: Inventory) {
+            this.backingInventory = inventory
+        }
+
+        override fun getInventory(): Inventory = backingInventory
+    }
+}

--- a/src/main/kotlin/pl/syntaxdevteam/punisher/gui/paper/PaperScreen.kt
+++ b/src/main/kotlin/pl/syntaxdevteam/punisher/gui/paper/PaperScreen.kt
@@ -1,0 +1,23 @@
+package pl.syntaxdevteam.punisher.gui.paper
+
+import net.kyori.adventure.text.Component
+import org.bukkit.entity.Player
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.inventory.Inventory
+
+/**
+ * Contract for Paper inventory screens managed by [PaperGuiAdapter].
+ */
+interface PaperScreen {
+    val id: String
+
+    fun title(viewer: Player): Component
+
+    fun size(viewer: Player): Int = 45
+
+    fun render(viewer: Player, inventory: Inventory)
+
+    fun handleClick(event: InventoryClickEvent, adapter: PaperGuiAdapter) {
+        event.isCancelled = true
+    }
+}

--- a/src/test/kotlin/pl/syntaxdevteam/punisher/gui/paper/PaperGuiAdapterIntegrationTest.kt
+++ b/src/test/kotlin/pl/syntaxdevteam/punisher/gui/paper/PaperGuiAdapterIntegrationTest.kt
@@ -1,0 +1,118 @@
+package pl.syntaxdevteam.punisher.gui.paper
+
+import be.seeseemelk.mockbukkit.MockBukkit
+import be.seeseemelk.mockbukkit.ServerMock
+import be.seeseemelk.mockbukkit.entity.PlayerMock
+import net.kyori.adventure.text.Component
+import org.bukkit.Material
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryAction
+import org.bukkit.event.inventory.InventoryClickEvent
+import org.bukkit.event.inventory.InventoryType
+import org.bukkit.plugin.java.JavaPlugin
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class PaperGuiAdapterIntegrationTest {
+
+    private lateinit var server: ServerMock
+    private lateinit var plugin: JavaPlugin
+    private lateinit var player: PlayerMock
+    private lateinit var adapter: PaperGuiAdapter
+    private lateinit var screen: DemoScreen
+
+    @BeforeEach
+    fun setUp() {
+        server = MockBukkit.mock()
+        plugin = MockBukkit.createMockPlugin()
+        player = server.addPlayer()
+        adapter = PaperGuiAdapter(plugin)
+        screen = DemoScreen()
+        adapter.register(screen).registerListener()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `open renders demo screen`() {
+        adapter.open(player, DemoScreen.ID)
+
+        val top = player.openInventory.topInventory
+        assertEquals(Component.text("Demo screen"), player.openInventory.title())
+        assertNotNull(top.getItem(13))
+        assertEquals(Material.EMERALD, top.getItem(13)?.type)
+        assertEquals(1, screen.renderCount)
+    }
+
+    @Test
+    fun `click is routed through adapter listener`() {
+        adapter.open(player, DemoScreen.ID)
+
+        val event = InventoryClickEvent(
+            player.openInventory,
+            InventoryType.SlotType.CONTAINER,
+            13,
+            ClickType.LEFT,
+            InventoryAction.PICKUP_ALL
+        )
+        server.pluginManager.callEvent(event)
+
+        assertTrue(event.isCancelled)
+        assertEquals(1, screen.clickCount)
+    }
+
+    @Test
+    fun `redraw re-renders current open inventory`() {
+        adapter.open(player, DemoScreen.ID)
+        screen.color = Material.DIAMOND
+
+        adapter.redraw(player)
+
+        val top = player.openInventory.topInventory
+        assertEquals(Material.DIAMOND, top.getItem(13)?.type)
+        assertEquals(2, screen.renderCount)
+    }
+
+    private class DemoScreen : PaperScreen {
+        companion object {
+            const val ID = "demo"
+        }
+
+        override val id: String = ID
+        var renderCount = 0
+        var clickCount = 0
+        var color: Material = Material.EMERALD
+
+        override fun title(viewer: org.bukkit.entity.Player): Component = Component.text("Demo screen")
+
+        override fun render(viewer: org.bukkit.entity.Player, inventory: org.bukkit.inventory.Inventory) {
+            renderCount++
+            val item = org.bukkit.inventory.ItemStack(color)
+            val meta = item.itemMeta
+            meta.displayName(Component.text("Odśwież"))
+            item.itemMeta = meta
+            inventory.setItem(13, item)
+            NavigationComponents.place(
+                inventory = inventory,
+                back = NavigationComponents.back(Component.text("Wróć")),
+                redraw = NavigationComponents.redraw(Component.text("Odśwież"))
+            )
+        }
+
+        override fun handleClick(event: InventoryClickEvent, adapter: PaperGuiAdapter) {
+            event.isCancelled = true
+            clickCount++
+            if (event.rawSlot == NavigationComponents.REDRAW_SLOT) {
+                adapter.redraw(event.whoClicked as org.bukkit.entity.Player)
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
### Motivation

- Wprowadzić integracyjne testy adaptera GUI dla Paper przy użyciu MockBukkit żeby mieć pewność że otwieranie, routing kliknięć i redraw działają poprawnie.
- Udostępnić wspólne komponenty nawigacyjne zgodne z układem ekranów PunisherX, żeby ujednolicić implementacje GUI.
- Zademonstrować jak spiąć listener (eventy) i renderer (renderowanie inventory) przykładową implementacją pluginową w module `example`.

### Description

- Dodano kontrakt ekranu `PaperScreen` i adapter `PaperGuiAdapter` obsługujący rejestrację ekranów, otwieranie, redraw i routing kliknięć (`InventoryClickEvent`).
- Dodano zestaw wielokrotnego użytku `NavigationComponents` z gotowymi itemami i stałymi slotów (`PREVIOUS_SLOT`, `BACK_SLOT`, `NEXT_SLOT`, `REDRAW_SLOT`) oraz helperem `place(...)`.
- Dodano integracyjne testy MockBukkit w `src/test/kotlin/.../PaperGuiAdapterIntegrationTest.kt`, pokrywające scenariusze: otwieranie ekranu, routowanie kliknięć przez adapter i redraw (ponowne renderowanie otwartego inventory).
- Dodano moduł `example` z przykładowym pluginem `ExamplePaperAdapterPlugin` pokazującym jak zarejestrować ekran i powiązać listener + renderer przez `PaperGuiAdapter`.
- Zaktualizowano konfigurację Gradle: dodanie repozytoriów dla `subprojects`, dodanie zależności testowej `MockBukkit-v1.21` oraz dopasowanie `paper-api` w testach (`1.21.1-R0.1-SNAPSHOT`) dla kompatybilności z MockBukkit.

### Testing

- Uruchomiono `chmod +x gradlew` aby upewnić się, że wrapper jest wykonywalny.
- Uruchomiono wszystkie testy Gradle z `./gradlew test --console=plain` i integracyjne testy MockBukkit (`PaperGuiAdapterIntegrationTest`) uruchomiły się w środowisku testowym.
- Wynik: `./gradlew test` zakończył się sukcesem (BUILD SUCCESSFUL) — testy integracyjne i istniejący zestaw testów jednostkowych przeszły poprawnie.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8e8e0d9f483298492a9e61ab1779c)